### PR TITLE
Juan

### DIFF
--- a/src/pyroofit/composites.py
+++ b/src/pyroofit/composites.py
@@ -181,9 +181,12 @@ class AddPdf(PDF):
                 roo_norm = create_roo_variable(norm_var)
             else:
                 roo_norm = self._external_norms[pdf_name]
-            self.norms[pdf_name] = roo_norm
-            self.parameters['n_' + pdf_name] = roo_norm
-            argset_norm.add(roo_norm)
+
+            if pdf.use_normalization:
+                self.norms[pdf_name] = roo_norm
+                self.parameters['n_' + pdf_name] = roo_norm
+                argset_norm.add(roo_norm)
+            
             argset_roo_pdf.add(pdf.roo_pdf)
 
             self.observables.update(pdf.observables)

--- a/src/pyroofit/pdf.py
+++ b/src/pyroofit/pdf.py
@@ -59,6 +59,8 @@ class PDF(ClassLoggingMixin, object):
     use_hesse = True
     use_extended = False
     use_sumw2error = True
+    use_strategy = 1
+    use_numcpu = 2
 
     def __init__(self, name, observables=None, title=None, **kwds):
         """ Init of the PDF class
@@ -239,12 +241,13 @@ class PDF(ClassLoggingMixin, object):
                                            ROOT.RooFit.Save(True),
                                            # ROOT.RooFit.Warnings(ROOT.kFALSE),
                                            ROOT.RooFit.PrintLevel(self.print_level),
-
                                            ROOT.RooFit.PrintEvalErrors(-1),
                                            ROOT.RooFit.Extended(self.use_extended),
                                            ROOT.RooFit.SumW2Error(self.use_sumw2error),
                                            ROOT.RooFit.Minos(self.use_minos),
-                                           ROOT.RooFit.Hesse(self.use_hesse), *args, **kwargs)
+                                           ROOT.RooFit.Hesse(self.use_hesse),
+                                           ROOT.RooFit.Hesse(self.use_strategy),
+                                           ROOT.RooFit.NumCPU(self.use_numcpu),*args, **kwargs)
 
     def plot(self, filename, data=None, observable=None, *args, **kwargs):
         """ Default plotting function

--- a/src/pyroofit/pdf.py
+++ b/src/pyroofit/pdf.py
@@ -61,6 +61,7 @@ class PDF(ClassLoggingMixin, object):
     use_sumw2error = True
     use_strategy = 1
     use_numcpu = 2
+    use_normalization = True
 
     def __init__(self, name, observables=None, title=None, **kwds):
         """ Init of the PDF class
@@ -246,8 +247,7 @@ class PDF(ClassLoggingMixin, object):
                                            ROOT.RooFit.SumW2Error(self.use_sumw2error),
                                            ROOT.RooFit.Minos(self.use_minos),
                                            ROOT.RooFit.Hesse(self.use_hesse),
-                                           ROOT.RooFit.Hesse(self.use_strategy),
-                                           ROOT.RooFit.NumCPU(self.use_numcpu),*args, **kwargs)
+                                           ROOT.RooFit.Strategy(self.use_strategy),*args, **kwargs)
 
     def plot(self, filename, data=None, observable=None, *args, **kwargs):
         """ Default plotting function


### PR DESCRIPTION
In the previous version, for each pdf in the model, it creates a RooRealVar for normalization. I added an option to don't set a normalization. Now we can write PDFs like:

PDF = NSig*(sig_frac*CB + (1-sig_frac)*Gauss) + NBkg*Exp

Before we were obliged to use:

PDF = NSig*(sig_frac1*CB + sig_frac2*Gauss) + NBkg*Exp